### PR TITLE
Added zoom-in, zoom-out and share buttons.

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -25,6 +25,10 @@ import { BaseLayerSelectionComponent } from './base-layer-selection/base-layer-s
 import { LayerOpacitySelectorComponent } from './layer-opacity-selector/layer-opacity-selector.component';
 import { AboutComponent } from './about/about.component';
 import { SplashModalComponent } from './splash-modal/splash-modal.component';
+import {ZoomInButtonComponent} from './zoom-in-map/zoom-in.component';
+import {ZoomOutButtonComponent} from './zoom-out-map/zoom-out.component';
+import {ShareModalComponent} from './share-modal/share-modal.component';
+import {ShareMapComponent} from './share-map/share-map.component';
 
 @NgModule({
   declarations: [
@@ -37,6 +41,10 @@ import { SplashModalComponent } from './splash-modal/splash-modal.component';
     SearchComponent,
     BaseLayerSelectionComponent,
     LayerOpacitySelectorComponent,
+    ZoomInButtonComponent,
+    ZoomOutButtonComponent,
+    ShareModalComponent,
+    ShareMapComponent,
     AboutComponent,
     SplashModalComponent
   ],
@@ -52,7 +60,7 @@ import { SplashModalComponent } from './splash-modal/splash-modal.component';
     MapWaldModule.forRoot({paths:routeParameters}),
     RouterModule.forRoot(routes,{ useHash: true })
   ],
-  entryComponents: [AboutComponent, SplashModalComponent],
+  entryComponents: [AboutComponent, SplashModalComponent, ShareModalComponent],
   providers: [SelectionService,LayersService],
   bootstrap: [AppComponent]
 })

--- a/src/app/main-map/main-map.component.html
+++ b/src/app/main-map/main-map.component.html
@@ -80,6 +80,14 @@
             </fmc-layer-opacity-selector>
           </div>
         </div>
+
+        <div class="card buttonContainer map-control">
+          <div class="card-block control-card-content">
+            <zoom-in-button (zoomPress)="zoomIn($event)"></zoom-in-button>
+            <zoom-out-button (zoomPress)="zoomOut($event)"></zoom-out-button>
+            <share-map></share-map>
+          </div>
+        </div>
       </map-control>
 
       <map-control position="LEFT_BOTTOM">

--- a/src/app/main-map/main-map.component.scss
+++ b/src/app/main-map/main-map.component.scss
@@ -26,6 +26,10 @@
   width: 200px;
 }
 
+.buttonContainer {
+  width: 55px;
+}
+
 .collapse-arrow {
   float: right;
 }

--- a/src/app/main-map/main-map.component.ts
+++ b/src/app/main-map/main-map.component.ts
@@ -262,4 +262,11 @@ export class MainMapComponent implements OnInit {
     this.mainLayer.opacity = opacity;
   }
 
+  zoomIn(zoom: number) {
+    this.zoom += zoom;
+  }
+
+  zoomOut(zoom: number) {
+    this.zoom -= zoom;
+  }
 }

--- a/src/app/share-map/share-map.component.html
+++ b/src/app/share-map/share-map.component.html
@@ -1,0 +1,3 @@
+<div>
+  <button (click)="shareView($event)"><span class="fa fa-share-alt"></span></button>
+</div>

--- a/src/app/share-map/share-map.component.scss
+++ b/src/app/share-map/share-map.component.scss
@@ -1,0 +1,13 @@
+button {
+  border:1px solid grey;
+  border-radius: 3px;
+  background:white;
+  font-size: 1.7em;
+  width: 100%;
+  height: 28px;
+}
+
+button:hover {
+  background-color: rgb(216,216,216);
+  cursor: pointer;
+}

--- a/src/app/share-map/share-map.component.ts
+++ b/src/app/share-map/share-map.component.ts
@@ -1,0 +1,25 @@
+import {AboutComponent} from '../about/about.component';
+import { Component, OnInit, EventEmitter, Output } from '@angular/core';
+import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
+import {ShareModalComponent} from '../share-modal/share-modal.component';
+
+@Component({
+  selector: 'share-map',
+  templateUrl: './share-map.component.html',
+  styleUrls: ['./share-map.component.scss']
+})
+export class ShareMapComponent implements OnInit {
+  @Output() zoomPress: EventEmitter<number> = new EventEmitter<number>();
+
+  constructor(private modalService: NgbModal) { }
+
+  ngOnInit() {
+  }
+
+  shareView(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    const modalRef = this.modalService.open(ShareModalComponent);
+  }
+
+}

--- a/src/app/share-modal/share-modal.component.html
+++ b/src/app/share-modal/share-modal.component.html
@@ -1,0 +1,58 @@
+<div class="modal-header">
+  <h3 class="modal-title">Share</h3>
+  <button type="button" class="close" aria-label="Close" (click)="activeModal.dismiss('Cross click')">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+<div class="modal-body">
+  <ul class="nav nav-tabs mb-3">
+    <li class="nav-item">
+      <a [class.active]="isVisible" class="nav-link" (click)="show(true)">Share</a>
+    </li>
+    <li class="nav-item">
+      <a [class.active]="!isVisible" class="nav-link" (click)="show(false)">Embed</a>
+    </li>
+  </ul>
+
+  <div *ngIf="isVisible">
+    <h6>Top-Level Site</h6>
+    <div class="form-group row mb-3">
+      <div class="col">
+        <div class="input-group input-group-sm">
+          <input value="http://wenfo.org/afms/" class="form-control form-control-sm" id="topLevelSite">
+          <button (click)="copyToClipboard('topLevelSite')" class="btn btn-success">Copy</button>
+        </div>
+      </div>
+    </div>
+    <h6>Current View</h6>
+    <div class="form-group row mb-3">
+      <div class="col">
+        <div class="input-group input-group-sm">
+          <input [(ngModel)]="currentView" class="form-control form-control-sm" id="currentSiteView">
+          <button (click)="copyToClipboard('currentSiteView')" class="btn btn-success">Copy</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div *ngIf="!isVisible">
+    <h6>Top-Level Site</h6>
+    <div class="form-group row mb-3">
+      <div class="col">
+        <div class="input-group input-group-sm">
+          <input [(ngModel)]="topLevelSiteEmbed" class="form-control form-control-sm" id="topLevelSiteEmbed">
+          <button (click)="copyToClipboard('topLevelSiteEmbed')" class="btn btn-success">Copy</button>
+        </div>
+      </div>
+    </div>
+    <h6>Current View</h6>
+    <div class="form-group row mb-3">
+      <div class="col">
+        <div class="input-group input-group-sm">
+          <input [(ngModel)]="currentViewEmbed" class="form-control form-control-sm" id="currentSiteViewEmbed">
+          <button (click)="copyToClipboard('currentSiteViewEmbed')" class="btn btn-success">Copy</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/share-modal/share-modal.component.scss
+++ b/src/app/share-modal/share-modal.component.scss
@@ -1,0 +1,3 @@
+button:hover, .nav-item:hover {
+  cursor: pointer;
+}

--- a/src/app/share-modal/share-modal.component.spec.ts
+++ b/src/app/share-modal/share-modal.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AboutComponent } from './share-modal.component';
+
+describe('AboutComponent', () => {
+  let component: AboutComponent;
+  let fixture: ComponentFixture<AboutComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ AboutComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AboutComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/share-modal/share-modal.component.ts
+++ b/src/app/share-modal/share-modal.component.ts
@@ -1,0 +1,32 @@
+import {Component, Input, OnInit} from '@angular/core';
+import {NgbActiveModal} from '@ng-bootstrap/ng-bootstrap';
+import {Router} from '@angular/router';
+
+@Component({
+  selector: 'share-modal-component',
+  templateUrl: './share-modal.component.html',
+  styleUrls: ['./share-modal.component.scss']
+})
+export class ShareModalComponent implements OnInit {
+  currentView = 'http://wenfo.org/afms/' + this.router.url;
+  currentViewEmbed = '<iframe width="800" height="600" frameborder="0" src="http://wenfo.org/afms/' + this.router.url + '"></iframe>';
+  topLevelSiteEmbed = '<iframe width="800" height="600" frameborder="0" src="http://wenfo.org/afms/"></iframe>';
+  isVisible = true;
+  constructor(public activeModal: NgbActiveModal, private router: Router) { }
+  ngOnInit() {
+  }
+
+  copyToClipboard(site) {
+    // Hardcoded based on IDs. Can be changed if required / needs to be extended.
+         (<HTMLInputElement>document.getElementById(site)).select();
+         document.execCommand('copy');
+  }
+
+  show(share) {
+    if (share) {
+      this.isVisible = true;
+    } else {
+      this.isVisible = false;
+    }
+  }
+}

--- a/src/app/zoom-in-map/zoom-in.component.html
+++ b/src/app/zoom-in-map/zoom-in.component.html
@@ -1,0 +1,3 @@
+<div>
+  <button (click)="zoomIn()"><span class="fa fa-plus"></span></button>
+</div>

--- a/src/app/zoom-in-map/zoom-in.component.scss
+++ b/src/app/zoom-in-map/zoom-in.component.scss
@@ -1,0 +1,13 @@
+button {
+  border:1px solid grey;
+  border-radius: 3px;
+  background:white;
+  font-size: 1.7em;
+  width: 100%;
+  height: 28px;
+}
+
+button:hover {
+  background-color: rgb(216,216,216);
+  cursor: pointer;
+}

--- a/src/app/zoom-in-map/zoom-in.component.ts
+++ b/src/app/zoom-in-map/zoom-in.component.ts
@@ -1,0 +1,19 @@
+import { Component, OnInit, EventEmitter, Output } from '@angular/core';
+
+@Component({
+  selector: 'zoom-in-button',
+  templateUrl: './zoom-in.component.html',
+  styleUrls: ['./zoom-in.component.scss']
+})
+export class ZoomInButtonComponent implements OnInit {
+  @Output() zoomPress: EventEmitter<number> = new EventEmitter<number>();
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+  zoomIn() {
+    this.zoomPress.emit(1);
+  }
+}

--- a/src/app/zoom-out-map/zoom-out.component.html
+++ b/src/app/zoom-out-map/zoom-out.component.html
@@ -1,0 +1,3 @@
+<div>
+  <button (click)="zoomOut()"><span class="fa fa-minus"></span></button>
+</div>

--- a/src/app/zoom-out-map/zoom-out.component.scss
+++ b/src/app/zoom-out-map/zoom-out.component.scss
@@ -1,0 +1,13 @@
+button {
+  border:1px solid grey;
+  border-radius: 3px;
+  background:white;
+  font-size: 1.7em;
+  width: 100%;
+  height: 28px;
+}
+
+button:hover {
+  background-color: rgb(216,216,216);
+  cursor: pointer;
+}

--- a/src/app/zoom-out-map/zoom-out.component.ts
+++ b/src/app/zoom-out-map/zoom-out.component.ts
@@ -1,0 +1,19 @@
+import { Component, OnInit, EventEmitter, Output } from '@angular/core';
+
+@Component({
+  selector: 'zoom-out-button',
+  templateUrl: './zoom-out.component.html',
+  styleUrls: ['./zoom-out.component.scss']
+})
+export class ZoomOutButtonComponent implements OnInit {
+  @Output() zoomPress: EventEmitter<number> = new EventEmitter<number>();
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+  zoomOut() {
+    this.zoomPress.emit(1);
+  }
+}

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -7,5 +7,5 @@ export const environment = {
   tds_server: 'http://dapds00.nci.org.au/thredds',
   gsky_server: 'http://130.56.242.4/ows',
   production: false,
-  google_maps_api_key: 'WENFO_GOOGLE_MAPS_API_KEY'
+  google_maps_api_key: 'AIzaSyDZdDuJidtW1BaxzTMfQDB7bluhn6tPGOE'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -7,5 +7,5 @@ export const environment = {
   tds_server: 'http://dapds00.nci.org.au/thredds',
   gsky_server: 'http://130.56.242.4/ows',
   production: false,
-  google_maps_api_key: 'AIzaSyDZdDuJidtW1BaxzTMfQDB7bluhn6tPGOE'
+  google_maps_api_key: 'WENFO_GOOGLE_MAPS_API_KEY'
 };


### PR DESCRIPTION
Created the zoom-in, zoom-out and share but

Share button uses two components (one for the modal and the initial modal trigger and the zoom buttons use a component each - let me know if I should be structuring these implements differently? 

Currently the zoom buttons functions use a default value of +1 / -1 from the zoom level. Google Maps suggests it be set as 4, so a zoom in would set this value to 5 and so-forth. This can be altered within the component typescript files if the zoom is too extreme. 

The share button links are the same which I pulled from ausenv, and uses angular routes to append to the stem of wenfo.org/afms/ - currently hardcoded. 